### PR TITLE
scrollableContainer should always be a jQuery object

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -12,7 +12,7 @@ fsm.directive('fsmStickyHeader', function(){
         link: function(scope, element, attributes, control){
             var header = $(element, this);
             var content = $(scope.scrollBody);
-            var scrollableContainer = $(scope.scrollableContainer)[0] || $(window);
+            var scrollableContainer = $(scope.scrollableContainer) || $(window);
             var clonedHeader = null;
 
             function createClone(){


### PR DESCRIPTION
When using the scrollableContainer option the jQuery object should not be accessed in the zero position since that returns the element without the jQuery wrapper thus it doesn't have scroll() or resize() methods to set the event handlers.