### PR TITLE
Use position instead of offset

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -53,7 +53,7 @@ fsm.directive('fsmStickyHeader', function(){
 
             function determineVisibility(){
                 var scrollTop = scrollableContainer.scrollTop() + scope.scrollStop;
-                var contentTop = content.offset().top;
+                var contentTop = content.position().top;
                 var contentBottom = contentTop + content.outerHeight(false);
 
                 if ( (scrollTop > contentTop) && (scrollTop < contentBottom) ) {


### PR DESCRIPTION
when using a scrollable container position should be used in order to get the coordinates relative to the parent conatiner and not the document itself.