### PR TITLE
Replaced position with offset

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -57,7 +57,7 @@ fsm.directive('fsmStickyHeader', function(){
 
             function determineVisibility(){
                 var scrollTop = scrollableContainer.scrollTop() + scope.scrollStop;
-                var contentTop = content.position().top;
+                var contentTop = content.offset().top;
                 var contentBottom = contentTop + content.outerHeight(false);
 
                 if ( (scrollTop > contentTop) && (scrollTop < contentBottom) ) {


### PR DESCRIPTION
Problem:
The table header 'fixed position' got triggered to fast because of containers.

Position returns the position relative to the offset parent, and offset does the same relative to the document, which in most cases is more useful and workable in containers.

Solution:
Changing position to offset gets a correct offset of the container position.