### PR TITLE
Fixed sticky container position when using scrollable-container.

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -36,7 +36,7 @@
 
                 function determineVisibility(){
                     var scrollTop = scrollableContainer.scrollTop() + scope.scrollStop;
-                    var contentTop = content.offset().top + contentOffset;
+                    var contentTop = content.offset().top + content.offsetParent().scrollTop() + contentOffset;
                     var contentBottom = contentTop + content.outerHeight(false);
 
                     if ( (scrollTop > contentTop) && (scrollTop < contentBottom) ) {


### PR DESCRIPTION
Content position was relative to document body (not to scroll
container) and changed during scroll events.