### PR TITLE
Update fsm-sticky-header.js

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -11,7 +11,8 @@
                 scrollBody: '=',
                 scrollStop: '=',
                 scrollableContainer: '=',
-                contentOffset: '='
+                contentOffset: '=',
+				fsmZIndex: '='
             },
             link: function(scope, element, attributes, control){
                 var header = $(element, this);
@@ -93,7 +94,7 @@
                     clonedHeader.addClass('fsm-sticky-header');
                     clonedHeader.css({
                         position: 'fixed',
-                        'z-index': 10000,
+                        'z-index': scope.fsmZIndex || 10000,
                         visibility: 'hidden'
                     });                
                     calculateSize();


### PR DESCRIPTION
When using sticky header underneath a bootstrap modal, the header appears in front of the modal. This gives the option for the user to decrease the z-index of the header to a number that would appear behind something else (setting it to 1000 gets it behind the bootstrap modal).