### PR TITLE
remove the CSS properties the script set itself

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -72,12 +72,12 @@
 
                             header.removeClass('fsm-sticky-header');
                             header.css({
-                                position: 'relative',
-                                left: 0,
-                                top: 0,
-                                width: 'auto',
-                                'z-index': 0,
-                                visibility: 'visible'
+                                position: '',
+                                left: '',
+                                top: '',
+                                width: '',
+                                'z-index': '',
+                                visibility: ''
                             });
                         }
                     }


### PR DESCRIPTION
instead of leaving behind potentially unwanted CSS on the original element 
(in my case the left behind z-index: 0 cause problems)