### PR TITLE
Make header scroll horizontally with the page

### DIFF
--- a/src/fsm-sticky-header.js
+++ b/src/fsm-sticky-header.js
@@ -46,6 +46,7 @@
 
                 function determineVisibility(){
                     var scrollTop = scrollableContainer.scrollTop() + scope.scrollStop;
+                    var scrollLeft = -scrollableContainer.scrollLeft() + content.offset().left;
                     var contentTop = content.offset().top + contentOffset;
                     var contentBottom = contentTop + content.outerHeight(false);
 
@@ -61,6 +62,7 @@
                         } else {
                             calculateSize();
                         }
+                        clonedHeader.css('left', scrollLeft + 'px');
                     } else {
                         if (clonedHeader){
                             /*


### PR DESCRIPTION
Could probably be cleaned up slightly, but this ensures that the header also scrolls horizontally with the page, including offset properly from the left based on the existing header's offset.
